### PR TITLE
fix: only poll Semaphore API if there is space for new jobs

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -77,7 +77,12 @@ func (c *Controller) tick(ctx context.Context) bool {
 		return true
 	}
 
-	klog.Infof("Polling job queue for %v", agentTypes)
+	if !c.jobScheduler.HasSpace() {
+		klog.Info("Not polling Semaphore API - no space")
+		return true
+	}
+
+	klog.InfoS("Polling Semaphore API", "types", agentTypes)
 	jobs, err := c.semaphoreClient.JobsFor(agentTypes)
 	if err != nil {
 		klog.Error(err, "error polling job queue")

--- a/pkg/controller/job_scheduler.go
+++ b/pkg/controller/job_scheduler.go
@@ -43,6 +43,10 @@ func (s *JobScheduler) RegisterInformer(informerFactory informers.SharedInformer
 	return err
 }
 
+func (s *JobScheduler) HasSpace() bool {
+	return len(s.current) < s.config.MaxParallelJobs
+}
+
 func (s *JobScheduler) Create(ctx context.Context, req semaphore.JobRequest, agentType *agenttypes.AgentType) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/controller/job_scheduler_test.go
+++ b/pkg/controller/job_scheduler_test.go
@@ -78,6 +78,7 @@ func Test__JobScheduler(t *testing.T) {
 		defer clear(scheduler.current)
 
 		// create jobs up to max
+		require.True(t, scheduler.HasSpace())
 		for i := 0; i < maxParallelJobs; i++ {
 			jobID := randJobID()
 			req := semaphore.JobRequest{JobID: jobID, MachineType: agentType.AgentTypeName}
@@ -85,6 +86,9 @@ func Test__JobScheduler(t *testing.T) {
 			_ = jobExists(t, scheduler, clientset, jobID)
 			require.True(t, scheduler.JobExists(jobID))
 		}
+
+		// no more space available
+		require.False(t, scheduler.HasSpace())
 
 		// creating a job returns an error now
 		jobID := randJobID()


### PR DESCRIPTION
### Issue

We always check the Semaphore API for new jobs, even if we are already at the limit and won't be able to create new jobs.

### Solution

On every controller's tick, if there is no space for more jobs, we don't even ask the Semaphore API for more jobs.