### PR TITLE
fix: OnAdd() panics when called for running job

### DIFF
--- a/pkg/controller/job_scheduler.go
+++ b/pkg/controller/job_scheduler.go
@@ -310,15 +310,12 @@ func (s *JobScheduler) isJobRunning(logger logr.Logger, jobID string, job *batch
 		return s.kubernetesMajorVersion, s.kubernetesMinorVersion
 	})
 
-	if running {
-		s.current[jobID].Running = true
-	}
-
 	return running
 }
 
 func (s *JobScheduler) handleInProgress(logger logr.Logger, jobID string, job *batchv1.Job) {
 	if s.isJobRunning(logger, jobID, job) {
+		s.current[jobID].Running = true
 		logger.Info("Job is running", "for", time.Since(job.Status.StartTime.Time))
 		return
 	}


### PR DESCRIPTION
### Issue

When `isJobRunning()` is called on the `OnAdd()` hook, it leads to a panic because `scheduler.current[jobID]` is not yet defined:

```
I0130 18:26:34.111326       1 job_scheduler.go:48] "Kubernetes version" version="v1.28.2"
I0130 18:26:34.112891       1 controller.go:61] "Starting controller"
I0130 18:26:34.116361       1 controller.go:80] No agent types found
I0130 18:26:34.116215       1 reflector.go:289] Starting reflector *v1.Secret (1m0s) from pkg/mod/k8s.io/client-go@v0.28.4/tools/cache/reflector.go:229
I0130 18:26:34.116280       1 reflector.go:289] Starting reflector *v1.Job (1m0s) from pkg/mod/k8s.io/client-go@v0.28.4/tools/cache/reflector.go:229
I0130 18:26:34.116999       1 reflector.go:325] Listing and watching *v1.Secret from pkg/mod/k8s.io/client-go@v0.28.4/tools/cache/reflector.go:229
I0130 18:26:34.117044       1 reflector.go:325] Listing and watching *v1.Job from pkg/mod/k8s.io/client-go@v0.28.4/tools/cache/reflector.go:229
I0130 18:26:34.146272       1 registry.go:44] Agent type added: s1-lucaspin-testing-3
I0130 18:26:34.146309       1 registry.go:44] Agent type added: s1-lucaspin-testing
E0130 18:26:34.149426       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 65 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x16879a0?, 0x26fe6b0})
	/Users/lucaspin/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x870c77?})
	/Users/lucaspin/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x16879a0?, 0x26fe6b0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/renderedtext/agent-k8s-stack/pkg/controller.(*JobScheduler).isJobRunning(0xc00042aa00, {{0x1b08b18?, 0xc00042aa80?}, 0xc00042a9c0?}, {0xc000638150, 0x24}, 0xc000500000?)
	/Users/lucaspin/Projects/semaphore/agent-k8s-controller/pkg/controller/job_scheduler.go:314 +0x11d
github.com/renderedtext/agent-k8s-stack/pkg/controller.(*JobScheduler).OnAdd(0xc00042aa00, {0x1889a40?, 0xc000262a00}, 0x10?)
	/Users/lucaspin/Projects/semaphore/agent-k8s-controller/pkg/controller/job_scheduler.go:262 +0x2ff
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/Users/lucaspin/go/pkg/mod/k8s.io/client-go@v0.28.4/tools/cache/shared_informer.go:974 +0x13e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
	/Users/lucaspin/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0000c0f38?, {0x1aee180, 0xc0000c2210}, 0x1, 0xc0001ae000)
	/Users/lucaspin/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
	/Users/lucaspin/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/Users/lucaspin/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/wait/backoff.go:161
k8s.io/client-go/tools/cache.(*processorListener).run(0xc000432990)
	/Users/lucaspin/go/pkg/mod/k8s.io/client-go@v0.28.4/tools/cache/shared_informer.go:968 +0x69
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	/Users/lucaspin/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/wait/wait.go:72 +0x4f
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 50
	/Users/lucaspin/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/wait/wait.go:70 +0x73
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x14be9dd]
```

### Solution

Do not mutate state inside `isRunningJob()`. Instead, let the callers do it.