### PR TITLE
fix: kubernetes version check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/go-logr/logr v1.4.1
+	github.com/hashicorp/go-version v1.6.0
 	github.com/stretchr/testify v1.8.2
 	k8s.io/api v0.28.4
 	k8s.io/apimachinery v0.28.4

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/pkg/controller/job_scheduler_test.go
+++ b/pkg/controller/job_scheduler_test.go
@@ -272,7 +272,7 @@ func newFakeClientset(t *testing.T, objects []runtime.Object) kubernetes.Interfa
 	fakeClientset := fake.NewSimpleClientset(objects...)
 	fakeDiscovery, ok := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
 	require.True(t, ok)
-	fakeDiscovery.FakedServerVersion = &version.Info{Major: "1", Minor: "27"}
+	fakeDiscovery.FakedServerVersion = &version.Info{GitVersion: "v1.27.1"}
 	return fakeClientset
 }
 


### PR DESCRIPTION
### Issue

The client-go library sometimes exposes versions that are not proper numbers. For example:

```
Server Version: version.Info{Major:"1", Minor:"23+", GitVersion:"v1.23.17-eks-c12679a"
```

### Solution

Use https://github.com/hashicorp/go-version and the `GitVersion` exposed by client-go, instead of trying to do integer parsing on the major/minor fields.