### PR TITLE
build: add release promotion

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -1,0 +1,26 @@
+version: v1.0
+name: Release
+agent:
+  machine:
+    type: e2-standard-2
+    os_image: ubuntu2004
+blocks:
+  - name: "Release"
+    task:
+      env_vars:
+        - name: GO111MODULE
+          value: "on"
+      secrets:
+        - name: dockerhub-write
+      prologue:
+        commands:
+          - sem-version go 1.22.7
+          - "export GOPATH=~/go"
+          - "export PATH=/home/semaphore/go/bin:$PATH"
+          - checkout
+      jobs:
+        - name: Release new version
+          commands:
+            - echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
+            - make docker.build
+            - make docker.push

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -56,3 +56,12 @@ after_pipeline:
       - name: Submit Reports
         commands:
           - test-results gen-pipeline-report
+
+promotions:
+  - name: Release
+    pipeline_file: "release.yml"
+    deployment_target: Release
+    auto_promote_on:
+      - result: passed
+        branch:
+          - "^refs/tags/v*"


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/7132

With this promotion, we can have just two steps for a new release:
1. Create new GH release (new tag)
2. Wait for Semaphore pipeline to finish on new tag, and for image to be built and pushed to DockerHub