### PR TITLE
fix(trivy): remove unused secrets and do not expose docker socket to trivy scans

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -14,9 +14,6 @@ blocks:
         - name: dockerhub-write
       prologue:
         commands:
-          - sem-version go 1.22.7
-          - "export GOPATH=~/go"
-          - "export PATH=/home/semaphore/go/bin:$PATH"
           - checkout
       jobs:
         - name: Release new version

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -39,13 +39,9 @@ blocks:
   - name: "Security checks"
     dependencies: []
     task:
-      secrets:
-        - name: security-toolbox-shared-read-access
       prologue:
         commands:
           - checkout
-          - mv ~/.ssh/security-toolbox ~/.ssh/id_rsa
-          - sudo chmod 600 ~/.ssh/id_rsa
       jobs:
         - name: Check dependencies
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,9 +24,7 @@ blocks:
       jobs:
         - name: Lint
           commands:
-            - sem-version go 1.22.3
             - checkout
-            - go install github.com/mgechev/revive@latest
             - make lint
         - name: Unit tests
           commands:
@@ -51,7 +49,6 @@ blocks:
             - make check.static
         - name: Check docker
           commands:
-            - sem-version go 1.22.7
             - make docker.build
             - make check.docker
       epilogue:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,6 @@
-FROM golang:1.24.11
+FROM golang:1.26.1
 
-RUN go install gotest.tools/gotestsum@v1.12.1
+RUN go install gotest.tools/gotestsum@v1.13.0
+RUN go install github.com/mgechev/revive@latest
 
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM golang:1.26.1
 
 RUN go install gotest.tools/gotestsum@v1.13.0
-RUN go install github.com/mgechev/revive@latest
+RUN go install github.com/mgechev/revive@v1.15.0
 
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,14 @@ check.generate-global-report: check.prepare
 
 
 lint:
-	revive -formatter friendly -config lint.toml ./...
+	docker compose run --rm app revive -formatter friendly -config lint.toml ./...
 
 test:
 	docker compose run --rm app gotestsum --format short-verbose --junitfile junit-report.xml --packages="./..." -- -p 1
 
 build:
 	rm -rf build
-	env GOOS=linux go build -o build/controller main.go
+	docker compose run --rm app env GOOS=linux go build -o build/controller main.go
 
 docker.build: build
 	docker build -t $(REGISTRY):latest .

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,14 @@ check.deps: check.prepare
 		bash -c 'cd $(APP_DIRECTORY) && $(SECURITY_TOOLBOX_TMP_DIR)/dependencies --language go -d'
 
 check.docker: check.prepare
-	docker run -it -v $$(pwd):$(APP_DIRECTORY) \
+	docker save $(REGISTRY):latest -o /tmp/trivy-image-scan.tar
+	docker run -it \
+		-v $$(pwd):$(APP_DIRECTORY) \
 		-v $(SECURITY_TOOLBOX_TMP_DIR):$(SECURITY_TOOLBOX_TMP_DIR) \
-		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /tmp/trivy-image-scan.tar:/tmp/trivy-image-scan.tar:ro \
 		registry.semaphoreci.com/ruby:3 \
-		bash -c 'cd $(APP_DIRECTORY) && $(SECURITY_TOOLBOX_TMP_DIR)/docker -d --image $(REGISTRY):latest --scanners $(SECURITY_SCANNERS)'
+		bash -c 'cd $(APP_DIRECTORY) && $(SECURITY_TOOLBOX_TMP_DIR)/docker -d --image /tmp/trivy-image-scan.tar --scanners $(SECURITY_SCANNERS)'; \
+	EXIT_CODE=$$?; rm -f /tmp/trivy-image-scan.tar; exit $$EXIT_CODE
 
 check.generate-report: check.prepare
 	docker run -it \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/renderedtext/agent-k8s-stack
 
-go 1.24.11
+go 1.26.1
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
This PR changes the way the trivy scans are run inside a Docker image to avoid exposing the Docker socket, which can possibly allow jumping out of the Docker container. It also bumps the version of Go to fix identified CVEs.